### PR TITLE
Add modern CSS demo showcasing modern selectors and transitions

### DIFF
--- a/web/css/README.md
+++ b/web/css/README.md
@@ -1,0 +1,10 @@
+# Modern CSS Demo
+
+This demo showcases a few modern CSS features:
+
+- Declarative cross-page transitions enabled via the View Transitions API.
+- The `:has()` selector to style a card when its image is hovered.
+- Container queries to adapt card layout when the container is wide enough.
+- `color-mix()` to blend colors declaratively.
+
+Open `index.html` in a modern browser to explore the examples.

--- a/web/css/index.html
+++ b/web/css/index.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Modern CSS Demo</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <nav>
+    <a href="page2.html">Go to Page 2</a>
+  </nav>
+
+  <section class="cards">
+    <article class="card">
+      <img src="https://via.placeholder.com/150" alt="Placeholder" />
+      <h2>Card Title</h2>
+      <p>Hover the image to see :has() in action.</p>
+    </article>
+    <article class="card">
+      <img src="https://via.placeholder.com/150/ff0000/ffffff" alt="Placeholder" />
+      <h2>Another Card</h2>
+      <p>Resize to trigger the container query.</p>
+    </article>
+  </section>
+</body>
+</html>

--- a/web/css/page2.html
+++ b/web/css/page2.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Modern CSS Demo - Page 2</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <nav>
+    <a href="index.html">Go back</a>
+  </nav>
+
+  <section class="cards">
+    <article class="card">
+      <img src="https://via.placeholder.com/150/00ff00/ffffff" alt="Placeholder" />
+      <h2>Second Page</h2>
+      <p>View transitions animate navigation between pages.</p>
+    </article>
+  </section>
+</body>
+</html>

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -1,0 +1,35 @@
+@view-transition {
+  navigation: auto;
+}
+
+::view-transition-group(*) {
+  animation-duration: 0.3s;
+}
+
+body {
+  font-family: system-ui, sans-serif;
+  margin: 2rem;
+}
+
+.cards {
+  display: grid;
+  gap: 1rem;
+}
+
+.card {
+  padding: 1rem;
+  border: 1px solid #ccc;
+  container-type: inline-size;
+}
+
+.card:has(img:hover) {
+  background: color-mix(in srgb, lightblue 30%, white);
+}
+
+@container (min-width: 400px) {
+  .card {
+    display: flex;
+    gap: 1rem;
+    align-items: center;
+  }
+}


### PR DESCRIPTION
## Summary
- add HTML/CSS demo highlighting view transitions, `:has()` selector, container queries, and `color-mix`

## Testing
- `npm test` *(fails: missing package.json)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b0425d43208328baf3c37699ca7f19